### PR TITLE
Change from fixed to sticky to fix issue

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -33,7 +33,7 @@ export const Navbar = () => {
 `;
 
   return (
-    <nav className="w-full fixed top-0 left-0 right-0 z-10">
+    <nav className="w-full sticky top-0 left-0 right-0 z-10">
       <div className="px-4 mx-auto lg:max-w-7xl md:flex md:items-center md:justify-between md:px-8">
         <div className="flex items-center justify-between py-3 md:py-5 md:block">
           {/* Logo goes here */}


### PR DESCRIPTION
## Description

Before, any new component created was showing on the left side of the navbar. This happened because the "fixed" property removes an element from the normal page layout. This means the element doesn't take up space, leading other elements to render behind or on top of it. To fix this, I changed the "fixed" property to "sticky".

## Acceptance Criteria
- [x] Any new component called after the Navbar component should appear below it, not on its side.